### PR TITLE
KOGITO-9800: [operator use case] Singleton Jobs Service per Namespace

### DIFF
--- a/infra/dataindex/02-dataindex.yaml
+++ b/infra/dataindex/02-dataindex.yaml
@@ -72,9 +72,9 @@ spec:
             name: dataindex-properties
       initContainers:
         - name: init-postgres
-          image: busybox:1.36
+          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'until nc -vz postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local 5432; do echo "Waiting for postgres server"; sleep 3; done;']
+          command: ['sh', '-c', 'until (echo 1 > /dev/tcp/postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/5432) >/dev/null 2>&1; do echo "Waiting for postgres server"; sleep 3; done;']
 ---
 apiVersion: v1
 kind: Service

--- a/infra/dataindex_and_jobservice/03-jobservice.yml
+++ b/infra/dataindex_and_jobservice/03-jobservice.yml
@@ -71,9 +71,9 @@ spec:
             name: jobs-service-properties
       initContainers:
         - name: init-postgres
-          image: busybox:1.36
+          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'until nc -vz postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local 5432; do echo "Waiting for postgres server"; sleep 3; done;']
+          command: ['sh', '-c', 'until (echo 1 > /dev/tcp/postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/5432) >/dev/null 2>&1; do echo "Waiting for postgres server"; sleep 3; done;']
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
    - move the data-index and jobs-service startup probes to use registry.access.redhat.com/ubi9/ubi-minimal