### PR TITLE
switch Red Hat postgres image

### DIFF
--- a/infra/dataindex/01-postgres.yaml
+++ b/infra/dataindex/01-postgres.yaml
@@ -30,29 +30,39 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:13.2-alpine
+          image: registry.redhat.io/rhel8/postgresql-13
           imagePullPolicy: 'IfNotPresent'
           ports:
             - containerPort: 5432
+              protocol: TCP
           volumeMounts:
             - name: storage
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/pgsql/data
           envFrom:
             - secretRef:
                 name: postgres-secrets
           readinessProbe:
             exec:
-              command: ["pg_isready"]
-            initialDelaySeconds: 15
-            timeoutSeconds: 2
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           livenessProbe:
             exec:
-              command: ["pg_isready"]
-            initialDelaySeconds: 15
-            timeoutSeconds: 2
+              command:
+                - /usr/libexec/check-container
+                - '--live'
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "500m"
       volumes:
       - name: storage

--- a/infra/dataindex/02-dataindex.yaml
+++ b/infra/dataindex/02-dataindex.yaml
@@ -36,12 +36,12 @@ spec:
             - name: QUARKUS_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: POSTGRES_USER
+                  key: POSTGRESQL_USER
                   name: postgres-secrets
             - name: QUARKUS_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: POSTGRES_PASSWORD
+                  key: POSTGRESQL_PASSWORD
                   name: postgres-secrets
           volumeMounts:
             - name: application-config

--- a/infra/dataindex/kustomization.yaml
+++ b/infra/dataindex/kustomization.yaml
@@ -5,10 +5,10 @@ resources:
 secretGenerator:
   - name: postgres-secrets
     literals:
-      - POSTGRES_USER=sonataflow
-      - POSTGRES_PASSWORD=sonataflow
-      - POSTGRES_DB=sonataflow
-      - PGDATA=/var/lib/postgresql/data/mydata
+      - POSTGRESQL_USER=sonataflow
+      - POSTGRESQL_PASSWORD=sonataflow
+      - POSTGRESQL_DATABASE=sonataflow
+      - PGDATA=/var/lib/pgsql/data/userdata
 
 configMapGenerator:
   - name: dataindex-properties

--- a/infra/dataindex_and_jobservice/03-jobservice.yml
+++ b/infra/dataindex_and_jobservice/03-jobservice.yml
@@ -35,12 +35,12 @@ spec:
             - name: QUARKUS_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: POSTGRES_USER
+                  key: POSTGRESQL_USER
                   name: postgres-secrets
             - name: QUARKUS_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: POSTGRES_PASSWORD
+                  key: POSTGRESQL_PASSWORD
                   name: postgres-secrets
           volumeMounts:
             - name: application-config


### PR DESCRIPTION
This image runs w/o issue in OpenShift. The current alpine image throws `FATAL: role ... does not exist` errors at runtime. 

_not sure we want to do this, as it would likely break k8s & minikube installs. this postgres repo requires terms acceptance and is only available on [registry.redhat.io](http://registry.redhat.io/)_